### PR TITLE
Avoid UTF-8 reencoding when appropriate.

### DIFF
--- a/dist/lt.bat
+++ b/dist/lt.bat
@@ -8,11 +8,19 @@ rem Set the translation table, this one is English UEB contracted
 set table=en-ueb-g2.ctb
 call %x%settable.bat
 
-rem pandoc to text then LouTran to braille with .brl appended to original file name
-copy %1 "%temp%\Utf8n%~x1"
-%x%Utf8n "%temp%\Utf8n%~x1"
-%x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table%> %1.brl 2> %temp%\lou_translate.log
-del "%temp%\Utf8n%~x1"
+rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
+set utf8=false
+if not "%~x1"==".docx" if not "%~x1"==".epub" if not "%~x1"==".odt" (
+    set utf8=true
+    copy %1 "%temp%\Utf8n%~x1"
+    %x%Utf8n "%temp%\Utf8n%~x1"
+    %x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+    del "%temp%\Utf8n%~x1"
+)
+if "%utf8%"=="false" (
+    %x%pandoc -t plain --wrap=preserve %1 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+)
+
 rem Open editor. Rem the following line to skip this step
 rem %x%bz.jar "%~1.brl"
 rem if you want, add a line like the one below to copy to a card. Set target to your drive

--- a/dist/lt1.bat
+++ b/dist/lt1.bat
@@ -6,11 +6,20 @@ set louis_tablepath=%x%tables\
 rem Set the translation table, this one is English UEB contracted
 set table=en-ueb-g1.ctb
 rem call %x%settable.bat
-rem pandoc to text then LouTran to braille with .brl appended to original file name
-copy %1 "%temp%\Utf8n%~x1"
-%x%Utf8n "%temp%\Utf8n%~x1"
-%x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
-del "%temp%\Utf8n%~x1"
+
+rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
+set utf8=false
+if not "%~x1"==".docx" if not "%~x1"==".epub" if not "%~x1"==".odt" (
+    set utf8=true
+    copy %1 "%temp%\Utf8n%~x1"
+    %x%Utf8n "%temp%\Utf8n%~x1"
+    %x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+    del "%temp%\Utf8n%~x1"
+)
+if "%utf8%"=="false" (
+    %x%pandoc -t plain --wrap=preserve %1 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+)
+
 rem Open editor. Rem the following line to skip this step
 rem %x%bz.jar "%~1.brl"
 rem if you want, add a line like the one below to copy to a card. Set target to your drive


### PR DESCRIPTION
## Why this pull request is needed:
When creating pull request #4, only ensuring compatibility with text-based markup languages was considered. All files were reencoded asUTF-8 if needed, which unfortunately negatively impacted any non-text formats such as Word Documents (.docx). As a result,Pandoc was unable to read such files due to the change in encoding -- akin to copying ASCII instead of binary.

## What this pull request does:
1. Using [Pandoc User’s Guide](https://pandoc.org/MANUAL.html), made a list of all formats that are neither plain text nor text markup languages. This task was made quite simple due to said formats being at the end of the list of supported input formats -- "... EPUB, ODT, and Word docx."
2. Wrote up a conditional statement using De Morgan's laws to exclude the three extensions for the filetypes listed above, creating a variable to store whether or not the reencoding process should be ran.

## Testing performed:
1. Converted a text file into both contracted and uncontracted UEB (using lt.bat and lt1.bat respectively), making sure that the input file was ran through the Utf8n executable.
2. Converted a Word Document (.docx) and an Epub file into both contracted and uncontracted UEB, making sure that the input file went directly to Pandoc.