### PR TITLE
Account for different case variations for file extensions when avoiding UTF-8 reencoding.

### DIFF
--- a/dist/lt.bat
+++ b/dist/lt.bat
@@ -8,11 +8,19 @@ rem Set the translation table, this one is English UEB contracted
 set table=en-ueb-g2.ctb
 call %x%settable.bat
 
-rem pandoc to text then LouTran to braille with .brl appended to original file name
-copy %1 "%temp%\Utf8n%~x1"
-%x%Utf8n "%temp%\Utf8n%~x1"
-%x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table%> %1.brl 2> %temp%\lou_translate.log
-del "%temp%\Utf8n%~x1"
+rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
+set utf8=false
+if not "%~x1"==".docx" if not "%~x1"==".epub" if not "%~x1"==".odt" (
+    set utf8=true
+    copy %1 "%temp%\Utf8n%~x1"
+    %x%Utf8n "%temp%\Utf8n%~x1"
+    %x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+    del "%temp%\Utf8n%~x1"
+)
+if "%utf8%"=="false" (
+    %x%pandoc -t plain --wrap=preserve %1 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+)
+
 rem Open editor. Rem the following line to skip this step
 rem %x%bz.jar "%~1.brl"
 rem if you want, add a line like the one below to copy to a card. Set target to your drive

--- a/dist/lt.bat
+++ b/dist/lt.bat
@@ -10,9 +10,9 @@ call %x%settable.bat
 
 rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
 set utf8=false
-if not "%~x1"==".docx" if not "%~x1"==".epub" if not "%~x1"==".odt" (
+if /I not "%~x1"==".docx" if /I not "%~x1"==".epub" if /I not "%~x1"==".odt" (
     set utf8=true
-    copy %1 "%temp%\Utf8n%~x1"
+    copy /B %1 "%temp%\Utf8n%~x1"
     %x%Utf8n "%temp%\Utf8n%~x1"
     %x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
     del "%temp%\Utf8n%~x1"

--- a/dist/lt1.bat
+++ b/dist/lt1.bat
@@ -6,11 +6,20 @@ set louis_tablepath=%x%tables\
 rem Set the translation table, this one is English UEB contracted
 set table=en-ueb-g1.ctb
 rem call %x%settable.bat
-rem pandoc to text then LouTran to braille with .brl appended to original file name
-copy %1 "%temp%\Utf8n%~x1"
-%x%Utf8n "%temp%\Utf8n%~x1"
-%x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
-del "%temp%\Utf8n%~x1"
+
+rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
+set utf8=false
+if not "%~x1"==".docx" if not "%~x1"==".epub" if not "%~x1"==".odt" (
+    set utf8=true
+    copy %1 "%temp%\Utf8n%~x1"
+    %x%Utf8n "%temp%\Utf8n%~x1"
+    %x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+    del "%temp%\Utf8n%~x1"
+)
+if "%utf8%"=="false" (
+    %x%pandoc -t plain --wrap=preserve %1 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
+)
+
 rem Open editor. Rem the following line to skip this step
 rem %x%bz.jar "%~1.brl"
 rem if you want, add a line like the one below to copy to a card. Set target to your drive

--- a/dist/lt1.bat
+++ b/dist/lt1.bat
@@ -9,9 +9,9 @@ rem call %x%settable.bat
 
 rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
 set utf8=false
-if not "%~x1"==".docx" if not "%~x1"==".epub" if not "%~x1"==".odt" (
+if /I not "%~x1"==".docx" if /I not "%~x1"==".epub" if /I not "%~x1"==".odt" (
     set utf8=true
-    copy %1 "%temp%\Utf8n%~x1"
+    copy /B %1 "%temp%\Utf8n%~x1"
     %x%Utf8n "%temp%\Utf8n%~x1"
     %x%pandoc -t plain --wrap=preserve "%temp%\Utf8n%~x1" 2> %temp%\pandoc.log|%x%lou_translate %table% > %1.brl 2> %temp%\lou_translate.log
     del "%temp%\Utf8n%~x1"


### PR DESCRIPTION
# Why this pull request is needed:
Extensions in mixed or uppercase was not accounted for by the conditional in pull request #7.

## What this pull request does:
1. It accounts for extension case variation, i.e., if it is uppercase, lowercase, or mixed case, thanks to the /I switch of the if conditional.
2. When copying for UTF-8 reencoding, copies in binary mode instead of ASCII, ensuring a byte-for-byte copy of the file in the %temp% directory.

## Tests performed:
1. Converted a file with a .docx extension, ensuring that the UTF-8 reencoding conditional did not run.
2. Converted a file with a .DOCX extension, ensuring that the UTF-8 reencoding conditional did not run.
3. Converted a file with a .DoCX extension, ensuring that the UTF-8 reencoding conditional did not run.