### PR TITLE
Added loop and shift to remaining batch files, i.e., lt1.bat and ltback.bat

### DIFF
--- a/dist/lt1.bat
+++ b/dist/lt1.bat
@@ -9,6 +9,7 @@ rem call %x%settable.bat
 
 rem pandoc to text then LouTran to braille with .brl appended to original file name, avoiding UTF-8 encoding when appropriate:
 set utf8=false
+:LOOP
 if /I not "%~x1"==".docx" if /I not "%~x1"==".epub" if /I not "%~x1"==".odt" (
     set utf8=true
     copy /B %1 "%temp%\Utf8n%~x1"
@@ -25,3 +26,5 @@ rem %x%bz.jar "%~1.brl"
 rem if you want, add a line like the one below to copy to a card. Set target to your drive
 set target=f:
 rem copy "%~1.brl" target
+shift
+if not [%1]==[] goto :Loop

--- a/dist/ltback.bat
+++ b/dist/ltback.bat
@@ -8,9 +8,12 @@ rem Set the translation table, this one is English UEB contracted
 set table=en-ueb-g2.ctb
 rem call %x%settable.bat
 
+:LOOP
 type %1|%x%lou_translate %louflg% %table%> %1.txt 2> %temp%\lou_translate.log
 rem Open editor. Rem the following line to skip this step
 rem %x%bz.jar "%~1.brl"
 rem if you want, add a line like the one below to copy to a card. Set target to your drive
 set target=f:
 rem copy "%~1.brl" target
+shift
+if not [%1]==[] goto :Loop


### PR DESCRIPTION
Using the structure in lt.bat, added the same iteration of %1 to go through other files (if any) to the other batch files used by send-to-braille.